### PR TITLE
Fix raw audio extensions

### DIFF
--- a/Sushi.Net.Library/Common/Extensions.cs
+++ b/Sushi.Net.Library/Common/Extensions.cs
@@ -41,6 +41,9 @@ namespace Sushi.Net.Library.Common
         public static string ToExtension(this string codec)
         {
             codec = codec.ToLowerInvariant();
+            if (codec.StartsWith("pcm_"))
+                // Use .wav for raw audio formats (http://trac.ffmpeg.org/wiki/audio%20types)
+                return ".wav";
             if (maps.ContainsKey(codec))
                 return maps[codec];
             return "." + codec;


### PR DESCRIPTION
Raw audio codecs are named pcm_* (e.g. pcm_s16le, see http://trac.ffmpeg.org/wiki/audio%20types). This results in incorrect extensions, thus crashing ffmpeg when using raw audio as input. Mapping these raw audio codecs to the .wav extension solves this issue.